### PR TITLE
Include URL to license

### DIFF
--- a/XcodeWarnings.xcconfig
+++ b/XcodeWarnings.xcconfig
@@ -1,6 +1,8 @@
-//  XcodeWarnings by Jon Reid, https://qualitycoding.org
-//  Copyright 2022 Jonathan M. Reid. See LICENSE.txt
-//  Source: https://github.com/jonreid/XcodeWarnings
+// XcodeWarnings by Jon Reid, https://qualitycoding.org
+// Copyright (c) 2022 Jonathan M. Reid.
+// License: https://github.com/jonreid/XcodeWarnings/blob/main/LICENSE.txt
+// Source: https://github.com/jonreid/XcodeWarnings
+// SPDX-License-Identifier: MIT
 
 // Apple Clang - Address Sanitizer
 CLANG_ADDRESS_SANITIZER_CONTAINER_OVERFLOW = YES


### PR DESCRIPTION
Edited license header to include URL to LICENSE.txt to avoid license ambiguity